### PR TITLE
Adds a feature to ignore some windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ You'll need the following dependencies to build:
 * valac
 * libsqlite3-dev
 * libgee-0.8-dev
+* libwnck-3-dev
 
 ## How To Install From Source
 

--- a/data/com.github.davidmhewitt.clipped.gschema.xml
+++ b/data/com.github.davidmhewitt.clipped.gschema.xml
@@ -11,6 +11,11 @@
       <summary>How many days to keep a clipboard entry since it was last pasted</summary>
       <description>Pasting an item regularly will keep it in the store, lesser used items will be purged</description>
     </key>
+    <key type="s" name="window-title-blackregex">
+      <default>""</default>
+      <summary>A regex for window titles to ignore</summary>
+      <description>Any window which has a title which matches this regex will be ignored by clipper. Use this for security sensitive applications like a password manager.</description>
+    </key>
   </schema>
 </schemalist>
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -57,14 +57,20 @@ public class Clipped.Application : Gtk.Application {
         var settings = new GLib.Settings (application_id + ".settings");
         var first_run = settings.get_boolean ("first-run");
         var retention_period = settings.get_uint ("days-to-keep-entries");
-
+        var blackregex = settings.get_string ("window-title-blackregex");
+        
         clipboard_store = new ClipboardStore (retention_period);
 
         settings.changed["days-to-keep-entries"].connect (() => {
             clipboard_store.set_retention_days (settings.get_uint ("days-to-keep-entries"));
         });
 
-        manager = new ClipboardManager ();
+        manager = new ClipboardManager (blackregex);
+
+        settings.changed["window-title-blackregex"].connect (() => {
+            manager.set_blackregex(settings.get_string ("window-title-blackregex"));
+        });
+        
         manager.start ();
 
         manager.on_text_copied.connect ((text) => {

--- a/src/PreferencesWindow.vala
+++ b/src/PreferencesWindow.vala
@@ -88,6 +88,10 @@ public class Clipped.PreferencesWindow : Gtk.Dialog {
         var retention_spinner = create_spinbutton (1, 90, 1);
         settings.bind ("days-to-keep-entries", retention_spinner, "value", SettingsBindFlags.DEFAULT);
 
+        var blackregex_label = create_label (_("Regex for window titles to ignore:"));
+        var blackregex_entry = create_entry ();
+        settings.bind ("window-title-blackregex", blackregex_entry, "text", SettingsBindFlags.DEFAULT);
+
         if (first_run) {
             general_grid.attach (autostart_warning_label, 0, 0, 2, 1);
         }
@@ -99,6 +103,9 @@ public class Clipped.PreferencesWindow : Gtk.Dialog {
 
         general_grid.attach (retention_label, 0, 3, 1, 1);
         general_grid.attach (retention_spinner, 1, 3, 1, 1);
+
+        general_grid.attach (blackregex_label, 0, 4, 1, 1);
+        general_grid.attach (blackregex_entry, 1, 4, 1, 1);
 
         return general_grid;
     }
@@ -126,5 +133,10 @@ public class Clipped.PreferencesWindow : Gtk.Dialog {
         button.hexpand = true;
 
         return button;
+    }
+
+    private Gtk.Entry create_entry () {
+        var entry = new Gtk.Entry ();
+        return entry;
     }
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -11,6 +11,7 @@ sources = files(
     'MainWindow.vala',
     'PreferencesWindow.vala'
 )
+add_global_arguments('-DWNCK_I_KNOW_THIS_IS_UNSTABLE', language : 'c')
 
 executable(
     meson.project_name(),
@@ -22,7 +23,8 @@ executable(
         dependency('gee-0.8'),
         dependency('gdk-x11-3.0'),
         dependency('xtst'),
-        dependency('x11')
+        dependency('x11'),
+        dependency('libwnck-3.0')
     ],
     install: true
 )


### PR DESCRIPTION
Adds a feature to ignore some windows. Use libwnck 3.0 to get the title of the
active window at the point where data is being inserted to the clipboard.
Compare that against a regex set by the user through the preference dialog. If
it matches don't store the text.

Resolves #2